### PR TITLE
Minor dependency fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abxtracted",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "description": "Abxtracted javascript client",
   "main": "dist/abxtracted.min.js",
   "scripts": {
@@ -9,6 +9,7 @@
   "author": "Lucas Merencia <lucas.merencia@gmail.com>",
   "license": "ISC",
   "devDependencies": {
+    "gulp": "^3.9.1",
     "gulp-replace": "^0.5.4",
     "webpack": "^2.2.1",
     "webpack-stream": "^3.2.0"


### PR DESCRIPTION
When installing dependencies locally, an error was fired:

``` shell
[11:23:23] Local gulp not found in ~/personal/repos/abxtracted-js
[11:23:23] Try running: npm install gulp
```

This changes solve the issue.