### PR TITLE
Allowing experiment complete to be called with no callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abxtracted",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Abxtracted javascript client",
   "main": "dist/abxtracted.min.js",
   "scripts": {

--- a/src/experiment.js
+++ b/src/experiment.js
@@ -27,13 +27,19 @@ Experiment.prototype.throwCustomerIdentificationError = function(errorCallback){
 function request(type, customerAction, params){
   var url;
   var errorCallback = getErrorCallback(params);
-  var customerId = params.customerId || customerAction();
+  var customerId = getCustomerId(params, customerAction);
   if(customerId){
     url = buildRequestUrl(type, customerId, this.projectId, this.experimentKey);
     http.get(url, params);
   } else if(errorCallback) {
     this.throwCustomerIdentificationError(errorCallback);
   }
+}
+
+function getCustomerId(params, customerAction){
+  if(params && params.customerId)
+    return params.customerId;
+  return customerAction();
 }
 
 function buildRequestUrl(type, customerId, projectId, experimentKey){
@@ -43,7 +49,7 @@ function buildRequestUrl(type, customerId, projectId, experimentKey){
 }
 
 function getErrorCallback(params){
-  return params.error;
+  return params ? params.error : null;
 }
 
 module.exports = Experiment;

--- a/src/http.js
+++ b/src/http.js
@@ -4,8 +4,8 @@ var _public = {};
 
 _public.get = function(url, params){
   var xhr = new XMLHttpRequest();
-  var success = params.success;
-  var error = params.error;
+  var success = getRequestCallback(params, 'success');
+  var error = getRequestCallback(params, 'error');
 
   xhr.onload = function() {
     if (xhr.readyState === 4) {
@@ -27,6 +27,10 @@ _public.get = function(url, params){
 _public.complete = function(response, callback){
   callback(response);
 };
+
+function getRequestCallback(params, callbackType){
+  return params ? params[callbackType] : null;
+}
 
 function parseResponse(responseText){
   var response;

--- a/test/experiment-test.js
+++ b/test/experiment-test.js
@@ -89,7 +89,7 @@ describe('Experiment', function() {
     expect(mockParams.error.firstCall.args[0]).to.equal(COOKIES_UNAVAILABLE_MESSAGE);
   });
 
-  it('should not call error on get scenario when build customer id was not possible and error callback was not given', function(){
+  it('should not call error on get scenario when build customer id has not been possible and error callback was not given', function(){
     stubCustomerBuildId.returns(null);
     var experiment = instantiateExperiment();
     delete mockParams.error;
@@ -135,6 +135,14 @@ describe('Experiment', function() {
     delete mockParams.error;
     experiment.throwCustomerIdentificationError = sinon.spy();
     experiment.complete(mockParams);
+    expect(experiment.throwCustomerIdentificationError.called).to.equal(false);
+  });
+
+  it('should not call error on experiment completation if params was not given', () => {
+    stubCustomerBuildId.returns(null);
+    var experiment = instantiateExperiment();
+    experiment.throwCustomerIdentificationError = sinon.spy();
+    experiment.complete();
     expect(experiment.throwCustomerIdentificationError.called).to.equal(false);
   });
 

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -101,4 +101,13 @@ describe('Http', function(){
     expect(spyHttpComplete.called).to.equal(false);
   });
 
+  it('should not call any callback on get complete if params is not given', function(){
+    var xhr = http.get(MOCK_URL);
+    xhr.readyState = 4;
+    xhr.status = 200;
+    xhr.onload();
+
+    expect(spyHttpComplete.called).to.equal(false);
+  });
+
 });


### PR DESCRIPTION
Our docs say that callbacks are optional when calling experiment complete methods, but a runtime error occurred when doing this. These changes fix the problem.